### PR TITLE
Performance/forward-closed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ clap = "2.33.3"
 serde_json = "1.0.59"
 itertools = "0.10.1"
 chrono = "0.4.19"
-biodivine-lib-bdd = "0.2.*"
-biodivine-lib-param-bn = "0.1.*"
+biodivine-lib-bdd = "0.3.*"
+biodivine-lib-param-bn = "0.2.3"
 
 [dev-dependencies]
 

--- a/src/aeon/reachability.rs
+++ b/src/aeon/reachability.rs
@@ -66,9 +66,7 @@ pub fn forward_closed(
     loop {
         let mut stop = true;
         for var in graph.as_network().variables().rev() {
-            let outside_successors = graph.var_post(var, &basin).minus(&basin);
-            let can_go_out = graph.var_pre(var, &outside_successors).intersect(&basin);
-
+            let can_go_out = graph.var_can_post_out(var, &basin);
             if !can_go_out.is_empty() {
                 basin = basin.minus(&can_go_out);
                 stop = false;


### PR DESCRIPTION
Since `0.2.3`, `biodivine-lib-param-bn` implements a new set of `pre`/`post` methods on the `SymbolicAsyncGraph` that can be used to compute direct successors/predecessors within and outside the initial set. The advantage of these methods is that they use fewer symbolic operations. 

Consequently, we can replace the `can_go_out` set computation within `forward_closed` routine with a single `var_can_post_out` function. The original computation uses 4 symbolic operations, the new method only uses 2 symbolic operations. As such, there is no change in "asymptotic" complexity, but the algorithm should be noticeably faster than the previous version.

Note that a similar approach could be used in `forward` and `backward`. However, in this case, no improvement can be achieved, since the computation of the `step` set requires two symbolic operations either way.

Review request: I have empirically verified the correctness of `var_can_post_out` on small examples, but before merging, it should be verified that the new method indeed produces the same control results as the previous implementation (while ideally also checking that the speed has improved).